### PR TITLE
Move function to 'helpers' module

### DIFF
--- a/tests/cypress/e2e/helpers.ts
+++ b/tests/cypress/e2e/helpers.ts
@@ -1,0 +1,26 @@
+export function createCmkAutomationUser(cmkUser: string, cmkPassword: string) {
+  cy.request({
+    method: 'DELETE',
+    url: Cypress.env('cypressToCheckmkUrl') + '/check_mk/api/1.0/objects/user_config/' + cmkUser,
+    auth: {
+      bearer: `${Cypress.env('cmkUsername')} ${Cypress.env('cmkPassword')}`,
+    },
+    failOnStatusCode: false,
+  });
+  cy.request({
+    method: 'POST',
+    url: Cypress.env('cypressToCheckmkUrl') + '/check_mk/api/1.0/domain-types/user_config/collections/all',
+    auth: {
+      bearer: `${Cypress.env('cmkUsername')} ${Cypress.env('cmkPassword')}`,
+    },
+    body: {
+      username: cmkUser,
+      fullname: cmkUser,
+      roles: ['admin'],
+      auth_option: {
+        auth_type: 'automation',
+        secret: cmkPassword,
+      },
+    },
+  });
+}

--- a/tests/cypress/e2e/spec.cy.ts
+++ b/tests/cypress/e2e/spec.cy.ts
@@ -1,36 +1,11 @@
+import { createCmkAutomationUser } from './helpers';
+
 describe('Source configuration', () => {
   const cmkUser = 'cmkuser';
   const cmkPassword = 'somepassword123457';
 
-  function createCmkAutomationUser() {
-    cy.request({
-      method: 'DELETE',
-      url: Cypress.env('cypressToCheckmkUrl') + '/check_mk/api/1.0/objects/user_config/' + cmkUser,
-      auth: {
-        bearer: `${Cypress.env('cmkUsername')} ${Cypress.env('cmkPassword')}`,
-      },
-      failOnStatusCode: false,
-    });
-    cy.request({
-      method: 'POST',
-      url: Cypress.env('cypressToCheckmkUrl') + '/check_mk/api/1.0/domain-types/user_config/collections/all',
-      auth: {
-        bearer: `${Cypress.env('cmkUsername')} ${Cypress.env('cmkPassword')}`,
-      },
-      body: {
-        username: cmkUser,
-        fullname: cmkUser,
-        roles: ['admin'],
-        auth_option: {
-          auth_type: 'automation',
-          secret: cmkPassword,
-        },
-      },
-    });
-  }
-
   it('configures the datasource correctly', () => {
-    createCmkAutomationUser();
+    createCmkAutomationUser(cmkUser, cmkPassword);
 
     cy.visit('/');
     cy.get('input[name="user"]').type(Cypress.env('grafanaUsername'));


### PR DESCRIPTION
createCmkAutomationUser function is here moved to a newly created 'helpers' module.
The idea is to store all future helper functions there while having only the CY tests in 'spec.cy.ts'