### PR TITLE
Add support for variables

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -8,7 +8,7 @@ import WebApiBackend from './backend/web';
 import { Backend as BackendType, CmkQuery, DataSourceOptions, Edition, ResponseDataAutocomplete } from './types';
 import { AutoCompleteParams } from './ui/autocomplete';
 import { createCmkContext } from './utils';
-import { WebApiResponse, buildRequestBody } from './webapi';
+import { WebApiResponse } from './webapi';
 
 export class DataSource extends DataSourceApi<CmkQuery> {
   webBackend: WebApiBackend;
@@ -29,12 +29,7 @@ export class DataSource extends DataSourceApi<CmkQuery> {
   }
 
   async autocompleterRequest<T>(api_url: string, data: unknown): Promise<FetchResponse<WebApiResponse<T>>> {
-    return this.webBackend.cmkRequest<T>({
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      url: `${this.instanceSettings.url}/cmk/check_mk/${api_url}`,
-      data: buildRequestBody(data),
-    });
+    return this.webBackend.autocompleterRequest(api_url, data);
   }
 
   async contextAutocomplete(

--- a/src/RequestSpec.ts
+++ b/src/RequestSpec.ts
@@ -43,7 +43,7 @@ export type FiltersRequestSpec = Pick<
 export interface TagValue {
   group?: string;
   tag?: string;
-  operator?: string;
+  operator?: 'is' | 'isnot';
 }
 
 export type GraphType = 'single_metric' | 'predefined_graph';

--- a/src/RequestSpec.ts
+++ b/src/RequestSpec.ts
@@ -3,6 +3,13 @@ export interface NegatableOption {
   negated: boolean;
 }
 
+export type ObjectType = 'host' | 'site' | 'service';
+
+export interface MetricFindQuery {
+  filter: Partial<FiltersRequestSpec>;
+  objectType: ObjectType;
+}
+
 export interface RequestSpec {
   // TODO: we need to rename graph_type, as the graph_type differentiates between graph and metric.
   // TODO: we also need to rename graph, as this could contain a metric name.

--- a/src/RequestSpec.ts
+++ b/src/RequestSpec.ts
@@ -26,6 +26,20 @@ export interface RequestSpec {
   graph: string | undefined;
 }
 
+// subset of RequestSpec used with the Filters Component
+export type FiltersRequestSpec = Pick<
+  RequestSpec,
+  | 'site'
+  | 'host_name'
+  | 'host_name_regex'
+  | 'host_in_group'
+  | 'host_labels'
+  | 'host_tags'
+  | 'service'
+  | 'service_regex'
+  | 'service_in_group'
+>;
+
 export interface TagValue {
   group?: string;
   tag?: string;

--- a/src/backend/types.ts
+++ b/src/backend/types.ts
@@ -1,10 +1,13 @@
-import { DataQueryRequest, DataQueryResponse } from '@grafana/data';
+import { DataQueryRequest, DataQueryResponse, MetricFindValue } from '@grafana/data';
 
+import { MetricFindQuery } from '../RequestSpec';
 import { CmkQuery, Edition } from '../types';
 
 export interface Backend {
   query: (options: DataQueryRequest<CmkQuery>) => Promise<DataQueryResponse>;
   testDatasource: () => Promise<unknown>;
+  metricFindQuery: (query: MetricFindQuery) => Promise<MetricFindValue[]>;
+  listSites: () => Promise<MetricFindValue[]>;
 }
 
 export interface DatasourceOptions {

--- a/src/module.ts
+++ b/src/module.ts
@@ -4,7 +4,9 @@ import { DataSource } from './DataSource';
 import { CmkQuery, DataSourceOptions } from './types';
 import { ConfigEditor } from './ui/ConfigEditor';
 import { QueryEditor } from './ui/QueryEditor';
+import { VariableQueryEditor } from './ui/VariableQueryEditor';
 
 export const plugin = new DataSourcePlugin<DataSource, CmkQuery, DataSourceOptions>(DataSource)
   .setConfigEditor(ConfigEditor)
+  .setVariableQueryEditor(VariableQueryEditor)
   .setQueryEditor(QueryEditor);

--- a/src/ui/VariableQueryEditor.tsx
+++ b/src/ui/VariableQueryEditor.tsx
@@ -1,0 +1,87 @@
+import { SelectableValue } from '@grafana/data';
+import { InlineFieldRow, Label, VerticalGroup } from '@grafana/ui';
+import { DataSource } from 'DataSource';
+import React from 'react';
+
+import { FiltersRequestSpec, MetricFindQuery, ObjectType } from '../RequestSpec';
+import { CheckMkGenericAsyncSelect } from './components';
+import { Filters } from './filters';
+
+interface VariableQueryProps {
+  query: MetricFindQuery | string;
+  onChange: (query: MetricFindQuery, definition: string) => void;
+  datasource: DataSource;
+}
+
+const formatDefinition = function (query: MetricFindQuery) {
+  return `${query.objectType}: ${JSON.stringify(query.filter)}`;
+};
+
+const FILTER_RESTRICTION: Record<string, Array<keyof FiltersRequestSpec>> = {
+  site: [],
+  host: ['site', 'host_name', 'host_name_regex', 'host_in_group', 'host_labels', 'host_tags'],
+  service: [
+    // TODO: deduplicate with host
+    'site',
+    'host_name',
+    'host_name_regex',
+    'host_in_group',
+    'host_labels',
+    'host_tags',
+    'service',
+    'service_regex',
+    'service_in_group',
+  ],
+};
+
+export const VariableQueryEditor = function (props: VariableQueryProps) {
+  const query: MetricFindQuery = typeof props.query === 'string' ? { filter: {}, objectType: 'host' } : props.query;
+
+  if (props.query === '') {
+    // first run ever, query holds default value
+    props.onChange(query, formatDefinition(query));
+  }
+
+  const objectTypeChange = (value: ObjectType) => {
+    query.objectType = value;
+    props.onChange(query, formatDefinition(query));
+  };
+
+  const filtersChange = (value: FiltersRequestSpec) => {
+    query.filter = value;
+    props.onChange(query, formatDefinition(query));
+  };
+
+  const objectTypeCompleter = async (): Promise<Array<SelectableValue<ObjectType>>> => [
+    { value: 'site', label: 'Site' },
+    { value: 'host', label: 'Host' },
+    { value: 'service', label: 'Service' },
+  ];
+
+  const restrictFilter = FILTER_RESTRICTION[query.objectType];
+
+  return (
+    <>
+      <VerticalGroup>
+        <InlineFieldRow>
+          <VerticalGroup>
+            <Label>Object type to query</Label>
+            <CheckMkGenericAsyncSelect<ObjectType>
+              showVariables={false}
+              inputId={'object_type'}
+              value={query.objectType}
+              onChange={objectTypeChange}
+              autocompleter={objectTypeCompleter}
+            />
+            <Filters
+              datasource={props.datasource}
+              onChange={filtersChange}
+              requestSpec={query.filter}
+              restrictedChildrenChoice={restrictFilter}
+            />
+          </VerticalGroup>
+        </InlineFieldRow>
+      </VerticalGroup>
+    </>
+  );
+};

--- a/src/ui/components.tsx
+++ b/src/ui/components.tsx
@@ -281,7 +281,7 @@ const SingleTag = (props: {
   const operatorAutocompleter = (prefix: string) =>
     Promise.resolve([
       { value: 'is', label: '=' },
-      { value: 'is not', label: '≠' },
+      { value: 'isnot', label: '≠' },
     ]);
   const tagAutocompleter = React.useCallback(
     (prefix: string) => autocompleter(prefix, 'choices', { groupId: groupId || '' }),
@@ -301,7 +301,7 @@ const SingleTag = (props: {
       />
       <CheckMkGenericAsyncSelect<string | undefined>
         width={8}
-        onChange={(val) => onChange({ ...value, operator: val ?? 'is' })}
+        onChange={(val: 'is' | 'isnot') => onChange({ ...value, operator: val ?? 'is' })}
         value={value.operator}
         autocompleter={operatorAutocompleter}
         inputId={'operator'}

--- a/src/ui/filters.tsx
+++ b/src/ui/filters.tsx
@@ -1,0 +1,188 @@
+import React from 'react';
+
+import { DataSource } from '../DataSource';
+import { RequestSpec } from '../RequestSpec';
+import { ResponseDataAutocomplete } from '../types';
+import {
+  CheckMkSelect,
+  CheckMkSelectNegatable,
+  Filter,
+  HostLabelFilter,
+  HostTagFilter,
+  OnlyActiveChildren,
+  OnlyActiveChildrenProps,
+} from './components';
+
+interface FiltersProp extends Omit<OnlyActiveChildrenProps, 'children'> {
+  datasource: DataSource;
+  onChange(value: Partial<RequestSpec>): void;
+}
+
+export const Filters = (props: FiltersProp): JSX.Element => {
+  const { requestSpec, restrictedChildrenChoice, datasource, onChange } = props;
+
+  const rs = requestSpec || {};
+
+  const [qSite, setQSite] = React.useState(rs.site);
+  const [qHost, setQHost] = React.useState({
+    host_name: rs.host_name,
+    host_name_regex: rs.host_name_regex,
+    host_in_group: rs.host_in_group,
+    host_labels: rs.host_labels,
+    host_tags: rs.host_tags,
+  } as Partial<RequestSpec>);
+  const [qService, setQService] = React.useState({
+    service: rs.service,
+    service_regex: rs.service_regex,
+    service_in_group: rs.service_in_group,
+  } as Partial<RequestSpec>);
+
+  function setSiteFilter(value: Partial<RequestSpec>) {
+    onChange({ ...rs, ...value });
+    setQSite(value.site);
+  }
+  function setHostFilter(value: Partial<RequestSpec>) {
+    onChange({ ...rs, ...value });
+    setQHost(value);
+  }
+  function setServiceFilter(value: Partial<RequestSpec>) {
+    onChange({ ...rs, ...value });
+    setQService(value);
+  }
+
+  const siteAutocompleter = React.useCallback(
+    async (prefix: string) => {
+      return await datasource.contextAutocomplete('sites', {}, prefix, { strict: false });
+    },
+    [datasource]
+  );
+  const hostAutocompleter = React.useCallback(
+    (prefix: string) =>
+      datasource.contextAutocomplete('monitored_hostname', { site: qSite }, prefix, { strict: 'with_source' }),
+    [datasource, qSite]
+  );
+  const hostLabelAutocompleter = React.useCallback(
+    // TODO: would have expected that the site is used as context!
+    (prefix: string) => datasource.contextAutocomplete('label', {}, prefix, { world: 'core' }),
+    [datasource]
+  );
+  const hostGroupAutocompleter = React.useCallback(
+    (prefix: string) =>
+      datasource.contextAutocomplete('allgroups', { site: qSite }, prefix, { group_type: 'host', strict: true }),
+    [datasource, qSite]
+  );
+  const hostTagAutocompleter = React.useCallback(
+    (prefix: string, mode: 'groups' | 'choices', context: Record<string, unknown>) => {
+      if (mode === 'groups') {
+        return datasource.contextAutocomplete('tag_groups', { site: qSite, ...context }, prefix, { strict: true });
+      } else {
+        return (async function () {
+          // TODO: would have expected that this is dependent on the site, but does not look like that?
+          const response = await datasource.autocompleterRequest<ResponseDataAutocomplete>('ajax_vs_autocomplete.py', {
+            ident: 'tag_groups_opt',
+            params: { group_id: context.groupId, strict: true },
+            value: prefix,
+          });
+          return response.data.result.choices.map(([value, label]: [string, string]) => ({
+            value,
+            label,
+          }));
+        })();
+      }
+    },
+    [datasource, qSite]
+  );
+
+  const serviceAutocompleter = React.useCallback(
+    (prefix: string) =>
+      datasource.contextAutocomplete('monitored_service_description', { site: qSite, ...qHost }, prefix, {
+        strict: true,
+      }),
+    [datasource, qSite, qHost]
+  );
+  const serviceGroupAutocompleter = React.useCallback(
+    (prefix: string) =>
+      datasource.contextAutocomplete('allgroups', { site: qSite, ...qHost }, prefix, {
+        group_type: 'service',
+        strict: true,
+      }),
+    [datasource, qSite, qHost]
+  );
+
+  if (restrictedChildrenChoice !== undefined && restrictedChildrenChoice.length === 0) {
+    return <i>No Filters available</i>;
+  }
+
+  return (
+    <OnlyActiveChildren
+      requestSpec={requestSpec}
+      restrictedChildrenChoice={restrictedChildrenChoice}
+      showRemoveButton={props.showRemoveButton}
+      showAddFilterDropdown={props.showAddFilterDropdown}
+    >
+      <CheckMkSelect
+        requestSpecKey={'site'}
+        label={'Site'}
+        value={qSite}
+        // TODO: onChange is used by OnlyActiveChildren with undefined as value
+        // this should be reflected by the type system.
+        onChange={(site) => setSiteFilter({ site: site })}
+        autocompleter={siteAutocompleter}
+      />
+      <CheckMkSelect
+        requestSpecKey={'host_name'}
+        label={'Hostname'}
+        value={qHost.host_name}
+        onChange={(host) => setHostFilter({ ...qHost, host_name: host })}
+        autocompleter={hostAutocompleter}
+      />
+      <Filter
+        requestSpecKey="host_name_regex"
+        label="Hostname regex"
+        value={qHost.host_name_regex}
+        onChange={(host_name_regex) => setHostFilter({ ...qHost, host_name_regex: host_name_regex })}
+      />
+      <CheckMkSelectNegatable
+        requestSpecKey="host_in_group"
+        label="Host in group"
+        value={qHost.host_in_group}
+        onChange={(host_in_group) => setHostFilter({ ...qHost, host_in_group: host_in_group })}
+        autocompleter={hostGroupAutocompleter}
+      />
+      <HostLabelFilter
+        label="Host labels"
+        requestSpecKey="host_labels"
+        value={qHost.host_labels}
+        onChange={(host_labels: string[]) => setHostFilter({ ...qHost, host_labels: host_labels })}
+        autocompleter={hostLabelAutocompleter}
+      />
+      <HostTagFilter
+        label="Host tags"
+        requestSpecKey="host_tags"
+        value={qHost.host_tags}
+        onChange={(host_tags) => setHostFilter({ ...qHost, host_tags: host_tags })}
+        autocompleter={hostTagAutocompleter}
+      />
+      <CheckMkSelect
+        requestSpecKey={'service'}
+        label={'Service'}
+        value={qService.service}
+        onChange={(service) => setServiceFilter({ ...qService, service: service })}
+        autocompleter={serviceAutocompleter}
+      />
+      <Filter
+        requestSpecKey="service_regex"
+        label="Service regex"
+        value={qService.service_regex}
+        onChange={(service_regex) => setServiceFilter({ ...qService, service_regex: service_regex })}
+      />
+      <CheckMkSelectNegatable
+        requestSpecKey="service_in_group"
+        label="Service in group"
+        value={qService.service_in_group}
+        onChange={(service_in_group) => setServiceFilter({ ...qService, service_in_group: service_in_group })}
+        autocompleter={serviceGroupAutocompleter}
+      />
+    </OnlyActiveChildren>
+  );
+};

--- a/tests/unit/ui/CheckMkAsyncSelect.test.tsx
+++ b/tests/unit/ui/CheckMkAsyncSelect.test.tsx
@@ -4,6 +4,15 @@ import * as React from 'react';
 
 import { CheckMkAsyncSelect } from '../../../src/ui/components';
 
+const mockTemplateSrv = {
+  getVariables: () => [],
+  replaceValue: (value) => value,
+};
+jest.mock('@grafana/runtime', () => ({
+  ...(jest.requireActual('@grafana/runtime') as unknown as object),
+  getTemplateSrv: () => mockTemplateSrv,
+}));
+
 describe('CheckMkAsyncSelect', () => {
   const autocompleter = jest.fn(async (prefix: string): Promise<Array<SelectableValue<string>>> => {
     if (prefix === 'sentinel') {

--- a/tests/unit/ui/QueryEditor.test.tsx
+++ b/tests/unit/ui/QueryEditor.test.tsx
@@ -7,6 +7,15 @@ import { defaultRequestSpec } from '../../../src/RequestSpec';
 import { CmkQuery } from '../../../src/types';
 import { QueryEditor } from '../../../src/ui/QueryEditor';
 
+const mockTemplateSrv = {
+  getVariables: () => [],
+  replaceValue: (value) => value,
+};
+jest.mock('@grafana/runtime', () => ({
+  ...(jest.requireActual('@grafana/runtime') as unknown as object),
+  getTemplateSrv: () => mockTemplateSrv,
+}));
+
 const completions: Record<string, Array<{ value: string; label: string }>> = {
   sites: [
     { value: 'site_1', label: 'Site One' },

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -1,0 +1,226 @@
+import { GraphType, RequestSpec } from '../../src/RequestSpec';
+import { Context, Params } from '../../src/types';
+import { replaceVariables, toLiveStatusQuery } from '../../src/utils';
+
+jest.mock('@grafana/runtime', () => ({
+  ...(jest.requireActual('@grafana/runtime') as unknown as object),
+  getTemplateSrv: () => ({
+    replace: jest.fn().mockImplementation((s: string) => s.replace('$var', 'replaced')),
+  }),
+}));
+
+describe('utils.replaceVariables', () => {
+  it('string', () => {
+    expect(replaceVariables({ host_name: '$var' })).toStrictEqual({ host_name: 'replaced' });
+  });
+  it('site', () => {
+    expect(replaceVariables({ site: '$var' })).toStrictEqual({ site: 'replaced' });
+  });
+  it('graph_type', () => {
+    expect(replaceVariables({ graph_type: '$var' as GraphType })).toStrictEqual({ graph_type: 'replaced' });
+  });
+  it('negatbale', () => {
+    expect(replaceVariables({ host_name_regex: { value: '.*$var.*', negated: false } })).toStrictEqual({
+      host_name_regex: { value: '.*replaced.*', negated: false },
+    });
+  });
+  it('host_labels', () => {
+    expect(replaceVariables({ host_labels: ['$var', 'smth'] })).toStrictEqual({ host_labels: ['replaced', 'smth'] });
+  });
+  it('host_tags', () => {
+    expect(
+      replaceVariables({
+        host_tags: [
+          { tag: '$var', group: 'gruppe', operator: 'is' },
+          { tag: 'tag', group: '$var', operator: 'is' },
+          { tag: 'tag', group: 'gruppe', operator: 'is' },
+        ],
+      })
+    ).toStrictEqual({
+      host_tags: [
+        { tag: 'replaced', group: 'gruppe', operator: 'is' },
+        { tag: 'tag', group: 'replaced', operator: 'is' },
+        { tag: 'tag', group: 'gruppe', operator: 'is' },
+      ],
+    });
+  });
+});
+
+describe('utils.toLiveStatusQuery', () => {
+  it('host', () => {
+    expect(
+      toLiveStatusQuery(
+        {
+          site: 'ut_site',
+          host_name: 'ut_hostname',
+          host_name_regex: { value: 'ut_host_regex', negated: false },
+          host_in_group: { value: 'Drucker', negated: false },
+          host_labels: ['cmk/site:cmk210d'],
+          host_tags: [{ group: 'criticality', operator: 'is', tag: 'prod' }, {}, {}],
+          service: 'Check_MK',
+          service_regex: { value: 'ut_service_regex', negated: false },
+          service_in_group: { value: 'APT_Updates', negated: false },
+        },
+        'host'
+      )
+    ).toStrictEqual({
+      query: {
+        expr: [
+          {
+            left: 'hosts.name',
+            op: '=',
+            right: 'ut_hostname',
+          },
+          {
+            left: 'hosts.name',
+            op: '~~',
+            right: 'ut_host_regex',
+          },
+          {
+            left: 'hosts.groups',
+            op: '>=',
+            right: 'Drucker',
+          },
+          {
+            left: 'hosts.labels',
+            op: '=',
+            right: "'cmk/site' 'cmk210d'",
+          },
+          {
+            left: 'hosts.tags',
+            op: '=',
+            right: "'criticality' 'prod'",
+          },
+        ],
+        op: 'and',
+      },
+      sites: ['ut_site'],
+    });
+  });
+
+  it('host negated', () => {
+    expect(
+      toLiveStatusQuery(
+        {
+          host_name_regex: { value: 'ut_host_regex', negated: true },
+          host_in_group: { value: 'Drucker', negated: true },
+          service_regex: { value: 'ut_service_regex', negated: true },
+          service_in_group: { value: 'APT_Updates', negated: true },
+        },
+        'host'
+      )
+    ).toStrictEqual({
+      query: {
+        expr: [
+          {
+            left: 'hosts.name',
+            op: '!~~',
+            right: 'ut_host_regex',
+          },
+          {
+            left: 'hosts.groups',
+            op: '!>=',
+            right: 'Drucker',
+          },
+        ],
+        op: 'and',
+      },
+      sites: [],
+    });
+  });
+
+  it('service', () => {
+    expect(
+      toLiveStatusQuery(
+        {
+          site: 'ut_site',
+          host_name: 'ut_hostname',
+          host_name_regex: { value: 'ut_host_regex', negated: false },
+          host_in_group: { value: 'Drucker', negated: false },
+          host_labels: ['cmk/site:cmk210d'],
+          host_tags: [{ group: 'criticality', operator: 'is', tag: 'prod' }, {}, {}],
+          service: 'Check_MK',
+          service_regex: { value: 'ut_service_regex', negated: false },
+          service_in_group: { value: 'APT_Updates', negated: false },
+        },
+        'service'
+      )
+    ).toStrictEqual({
+      query: {
+        expr: [
+          {
+            left: 'services.host_name',
+            op: '=',
+            right: 'ut_hostname',
+          },
+          {
+            left: 'services.host_name',
+            op: '~~',
+            right: 'ut_host_regex',
+          },
+          {
+            left: 'services.host_groups',
+            op: '>=',
+            right: 'Drucker',
+          },
+          {
+            left: 'services.host_labels',
+            op: '=',
+            right: "'cmk/site' 'cmk210d'",
+          },
+          {
+            left: 'services.host_tags',
+            op: '=',
+            right: "'criticality' 'prod'",
+          },
+          {
+            left: 'services.description',
+            op: '=',
+            right: 'Check_MK',
+          },
+          {
+            left: 'services.description',
+            op: '~~',
+            right: 'ut_service_regex',
+          },
+          {
+            left: 'services.groups',
+            op: '>=',
+            right: 'APT_Updates',
+          },
+        ],
+        op: 'and',
+      },
+      sites: ['ut_site'],
+    });
+  });
+
+  it('service negated', () => {
+    expect(
+      toLiveStatusQuery(
+        {
+          service_regex: { value: 'ut_service_regex', negated: true },
+          service_in_group: { value: 'APT_Updates', negated: true },
+        },
+        'service'
+      )
+    ).toStrictEqual({
+      query: {
+        expr: [
+          {
+            left: 'services.description',
+            op: '!~~',
+            right: 'ut_service_regex',
+          },
+          {
+            left: 'services.groups',
+            op: '!>=',
+            right: 'APT_Updates',
+          },
+        ],
+        op: 'and',
+      },
+      sites: [],
+    });
+  });
+});


### PR DESCRIPTION
Requested in #28 and [feature-295540](https://features.checkmk.com/suggestions/295540/).

You should now be able to create query variables, and use them in the query editor. This feature is fully functional in all checkmk editions.