### PR TITLE
change default plugin id in src/plugin.json

### DIFF
--- a/.github/build/action.yml
+++ b/.github/build/action.yml
@@ -34,19 +34,9 @@ runs:
         mv ./src/plugin.new.json ./src/plugin.json
       if: ${{ inputs.release == 'false' }}
 
-    - name: Adapt plugin id and name of plugin
+    - name: Adapt README.md
       shell: bash
       run: |
-        # rename plugin description
-        jq ".info.description = \"Checkmk data source for Checkmk Cloud Edition\"" ./src/plugin.json > ./src/plugin.new.json
-        mv ./src/plugin.new.json ./src/plugin.json
-        # rename plugin name
-        jq ".name = \"Checkmk for Cloud Edition\"" ./src/plugin.json > ./src/plugin.new.json
-        mv ./src/plugin.new.json ./src/plugin.json
-        # rename plugin id
-        jq '.id = "checkmk-cloud-datasource"' ./src/plugin.json > ./src/plugin.new.json
-        mv ./src/plugin.new.json ./src/plugin.json
-        # rename README.md
         OLD_NAME="Checkmk data source"
         NEW_NAME="Checkmk data source for Checkmk Cloud Edition"
         # make sure we can actually find and replace OLD_NAME in README.md
@@ -57,6 +47,7 @@ runs:
     - name: Build signed plugin and test frontend
       shell: bash
       run: |
+        # yarn build script will adapt src/plugin.json via utils/plugin_json*.sh
         yarn run build:cloud
         yarn run sign
       if: ${{ inputs.signed == 'true'}}
@@ -64,6 +55,7 @@ runs:
     - name: Build unsigned plugin and test frontend
       shell: bash
       run: |
+        # yarn build script will adapt src/plugin.json via utils/plugin_json*.sh
         yarn run build
       if: ${{ inputs.signed == 'false' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,25 @@ on:
     - cron: '38 0 * * *' # every day at randint(0, 60) minutes after midnight
 
 jobs:
+  test-plugin-json:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get install jq
+
+      - name: plugin_json_to_unsigned.sh should not change src.plugin.json
+        run: |
+          # src/plugin.json and plugin_json_to_cloud.sh 
+          # should contain the same ids and strings
+          # this test makes sure they stay in sync
+          jq --sort-keys . src/plugin.json > /tmp/before.json
+          bash utils/plugin_json_to_unsigned.sh
+          jq --sort-keys . src/plugin.json > /tmp/after.json
+          diff /tmp/before.json /tmp/after.json
+
   build:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
         run: |
           sudo apt-get install jq
 
-      - name: plugin_json_to_unsigned.sh should not change src.plugin.json
+      - name: plugin_json_to_cloud.sh should not change src.plugin.json
         run: |
           # src/plugin.json and plugin_json_to_cloud.sh 
           # should contain the same ids and strings
           # this test makes sure they stay in sync
           jq --sort-keys . src/plugin.json > /tmp/before.json
-          bash utils/plugin_json_to_unsigned.sh
+          bash utils/plugin_json_to_cloud.sh
           jq --sort-keys . src/plugin.json > /tmp/after.json
           diff /tmp/before.json /tmp/after.json
 

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "3.0.1",
   "description": "",
   "scripts": {
-    "build": "webpack -c ./webpack.config.ts --env production",
-    "build:cloud": "BUILD_EDITION=CLOUD webpack -c ./webpack.config.ts --env production",
+    "build": "bash utils/plugin_json_to_unsigned.sh && webpack -c ./webpack.config.ts --env production",
+    "build:cloud": "bash utils/plugin_json_to_cloud.sh && BUILD_EDITION=CLOUD webpack -c ./webpack.config.ts --env production",
     "dev": "webpack -w -c ./webpack.config.ts --env development",
     "lint": "eslint --cache --ignore-path ./.gitignore --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "yarn lint --fix",

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
   "type": "datasource",
-  "name": "Checkmk",
-  "id": "tribe-29-checkmk-datasource",
+  "name": "Checkmk for Cloud Edition",
+  "id": "checkmk-cloud-datasource",
   "metrics": true,
   "info": {
-    "description": "Checkmk data source",
+    "description": "Checkmk data source for Checkmk Cloud Edition",
     "author": {
       "name": "Checkmk GmbH",
       "url": "https://github.com/Checkmk/"

--- a/utils/plugin_json_to_cloud.sh
+++ b/utils/plugin_json_to_cloud.sh
@@ -1,0 +1,8 @@
+jq ".info.description = \"Checkmk data source for Checkmk Cloud Edition\"" ./src/plugin.json > ./src/plugin.new.json
+mv ./src/plugin.new.json ./src/plugin.json
+
+jq ".name = \"Checkmk for Cloud Edition\"" ./src/plugin.json > ./src/plugin.new.json
+mv ./src/plugin.new.json ./src/plugin.json
+
+jq '.id = "checkmk-cloud-datasource"' ./src/plugin.json > ./src/plugin.new.json
+mv ./src/plugin.new.json ./src/plugin.json

--- a/utils/plugin_json_to_unsigned.sh
+++ b/utils/plugin_json_to_unsigned.sh
@@ -1,0 +1,8 @@
+jq ".info.description = \"Checkmk data source\"" ./src/plugin.json > ./src/plugin.new.json
+mv ./src/plugin.new.json ./src/plugin.json
+
+jq ".name = \"Checkmk\"" ./src/plugin.json > ./src/plugin.new.json
+mv ./src/plugin.new.json ./src/plugin.json
+
+jq '.id = "tribe-29-checkmk-datasource"' ./src/plugin.json > ./src/plugin.new.json
+mv ./src/plugin.new.json ./src/plugin.json


### PR DESCRIPTION
We are building two different versions of the plugin and grafana support suggested we should use the plugin id we publish in the grafana store as the default id which is `checkmk-cloud-datasource`.