### PR TITLE
Fix error in grafana 9.6.3

### DIFF
--- a/src/ui/VariableQueryEditor.tsx
+++ b/src/ui/VariableQueryEditor.tsx
@@ -43,8 +43,11 @@ export const VariableQueryEditor = function (props: VariableQueryProps) {
   }
 
   const objectTypeChange = (value: ObjectType) => {
-    query.objectType = value;
-    props.onChange(query, formatDefinition(query));
+    const newQuery: MetricFindQuery = {
+      ...query,
+      objectType: value,
+    };
+    props.onChange(newQuery, formatDefinition(newQuery));
   };
 
   const filtersChange = (value: FiltersRequestSpec) => {


### PR DESCRIPTION
"Object type to query" could not be changed in grafana 9.6.3 error message visible in console was:

Uncaught TypeError: "objectType" is read-only
    objectTypeChange VariableQueryEditor.tsx:46