### PR TITLE
Names updates and version check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ e2e-results/
 
 # Editor
 .idea
+.vscode
 
 
 # cypress atrifacts

--- a/src/backend/rest.ts
+++ b/src/backend/rest.ts
@@ -176,9 +176,14 @@ export default class RestApiBackend implements Backend {
         `Checkmk version 2.1.0 has been detected, but this plugin is configured to use version 2.2.0 and above. Please set the backend option to '< 2.2'.`
       );
     }
-    if (this.datasource.getEdition() === 'CEE' && result.data.edition === 'raw') {
+    if (this.datasource.getEdition() !== 'RAW' && result.data.edition === 'cre') {
       throw new Error(
-        'The data source specified the Checkmk Enterprise Edition, but Checkmk Raw Edition was detected. Please choose the raw edition in the data source settings.'
+        'The data source specified the Checkmk commercial editions, but Checkmk Raw Edition was detected. Choose the raw edition in the data source settings.'
+      );
+    }
+    if (this.datasource.getEdition() === 'RAW' && result.data.edition !== 'cre') {
+      throw new Error(
+        'The data source specified the Checkmk Raw Edition, but a Checkmk commercial edition was detected. Some functionality may not be available. Choose commercial editions in the data source settings to enable all features.'
       );
     }
     // The REST API would be ok with other users, but the autocompleter are not

--- a/src/ui/ConfigEditor.tsx
+++ b/src/ui/ConfigEditor.tsx
@@ -87,8 +87,8 @@ export class ConfigEditor extends PureComponent<Props, State> {
     }
 
     const cmkEditions: EditionOption[] = [
-      { value: 'CEE', label: 'Enterprise Editions' },
-      { value: 'RAW', label: 'RAW Edition' },
+      { value: 'CEE', label: 'Commercial editions' },
+      { value: 'RAW', label: 'Raw Edition' },
     ];
     if (!jsonData.edition) {
       this.onEditionChange(cmkEditions[0]);

--- a/tests/cypress/e2e/spec.cy.ts
+++ b/tests/cypress/e2e/spec.cy.ts
@@ -8,8 +8,8 @@ describe('e2e tests', () => {
   const hostName0 = 'localhost_grafana0';
   const hostName1 = 'localhost_grafana1';
 
-  const CmkCEE = 'Enterprise Editions';
-  const CmkCRE = 'RAW Edition';
+  const CmkCEE = 'Commercial editions';
+  const CmkCRE = 'Raw Edition';
 
   const inputDatasourceId = 'data-source-picker';
   const inputFilterId = 'react-select-7-input';


### PR DESCRIPTION
Change _Enterprise Edition_  to _commercial edition_ as it is the official name of non-RAW editions. 

  Also there is a better check for edition mismatch (When setting up a RAW edition and connect to a commercial one or vice versa. In case of a Raw edition setup connecting to a commercial edition instance, the error message will notify that some functionality might not be available. 