### PR TITLE
Add inputId attribute to filter selector to facilitate end-to-end testing

### DIFF
--- a/src/ui/components.tsx
+++ b/src/ui/components.tsx
@@ -174,7 +174,7 @@ export const CheckMkSelect = <Key extends RequestSpecStringKeys>(props: CheckMkS
   return (
     <InlineField labelWidth={LABEL_WIDTH} label={props.label}>
       <CheckMkAsyncSelect
-        inputId={`input_${props.label}`}
+        inputId={`input_${props.label?.replace(/ /g, "_")}`}
         label={label}
         autocompleter={autocompleter}
         onChange={onChange}
@@ -487,6 +487,7 @@ export const OnlyActiveChildren = (props: OnlyActiveChildrenProps): JSX.Element 
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             onChange={(value) => setActiveComponents((c) => [...c, value.value!])}
             value={{ label: 'Add Filter' }}
+            inputId="input_add_filter"
           />
         </InlineField>
       )}


### PR DESCRIPTION
Setting inputId field on add filter component helps to write tests by setting a stable selector. Before this change, the name generated was like react-select-#-input (Where # is a number)