### PR TITLE
Remove decimals from time periods

### DIFF
--- a/src/backend/rest.ts
+++ b/src/backend/rest.ts
@@ -265,6 +265,9 @@ export default class RestApiBackend implements Backend {
       throw 'Query is missing required fields';
     }
 
+    range.from.set('milliseconds', 0);
+    range.to.set('milliseconds', 0);
+
     const commonRequest: CommonRequest = {
       type: query.requestSpec.graph_type,
       time_range: {


### PR DESCRIPTION
Since a recent change in Check mk the time interval can only contain integers (No sub-second accuracy). This change removes the milliseconds from the time interval.

CMK-15113