### PR TITLE
Fix test not working due to changes on Grafana

### DIFF
--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -37,7 +37,7 @@ Cypress.Commands.add('addCmkDatasource', (cmkUser: string, cmkPass: string, edit
   cy.visit('/datasources/new');
   cy.get(GrafanaSelectors.AddDataSource.select_datasource_button('Checkmk')).contains('Checkmk').click();
 
-  cy.get(CheckMkSelectors.SetupForm.name).type(' ' + edition);
+  cy.get(CheckMkSelectors.SetupForm.name).clear().type(`Checkmk ${edition}`);
   cy.get(CheckMkSelectors.SetupForm.url).type(Cypress.env('grafanaToCheckmkUrl'));
   cy.get(CheckMkSelectors.SetupForm.edition).type(edition + '{enter}');
   cy.contains(edition).should('exist');

--- a/tests/cypress/support/grafana_selectors.ts
+++ b/tests/cypress/support/grafana_selectors.ts
@@ -11,7 +11,7 @@ const Selectors = {
   Login: {
     username_input: 'input[name="user"]',
     password_input: 'input[name="password"]',
-    login_button: 'button[aria-label="Login button"]',
+    login_button: 'button[data-testid="data-testid Login button"]',
   },
 
   AddDataSource: {


### PR DESCRIPTION
Last Grafana's version updated some controls at the login page and our tests were unable to run. This commit updates the selectors on our test suite

CMK-15488