### PR TITLE
Dropped support for Grafana prior 9.5.15

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -30,7 +30,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": ">=9.0.0",
+    "grafanaDependency": ">=9.5.15",
     "plugins": []
   },
   "routes": [


### PR DESCRIPTION
Currently Grafana 9.5.0 is the oldest supported version. In addition this plugin uses the <Toggletip> component introduced in that version.