### PR TITLE
more specific error message

### DIFF
--- a/src/backend/rest.ts
+++ b/src/backend/rest.ts
@@ -233,7 +233,7 @@ export default class RestApiBackend implements Backend {
       // but we may have a more detailed error message
       if (error.status === 404) {
         throw new Error(
-          'REST API graph endpoint is unavailable. Choose correct Checkmk edition and version in data source settings.'
+          'REST API endpoint returned 404 (not found) error. Choose correct Checkmk edition and version in data source settings and make sure URL is correct.'
         );
       }
 


### PR DESCRIPTION
This error case is also triggered if you have a typo in your site name, so we should mentions this as possible source.