### PR TITLE
Update node version on the CI action as the compatibilty check fails …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
           cache: 'yarn'
 
       - name: Install dependencies


### PR DESCRIPTION
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'yallist@5.0.0',
npm WARN EBADENGINE   required: { node: '>=18' },
npm WARN EBADENGINE   current: { node: 'v16.20.2', npm: '8.19.4' }
npm WARN EBADENGINE }

file:///home/runner/.npm/_npx/2c0e39c97cd6b26d/node_modules/execa/lib/utils/max-listeners.js:1
import {addAbortListener} from 'node:events';