### PR TITLE
Skip signed plugin build on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build frontend signed
+        if: github.event_name != 'pull_request'
         id: build-signed
         uses: ./.github/build/
         env:


### PR DESCRIPTION
A pull request from a fork is not able to build the signed plugin due to the secret API KEY, so this step should be skipped. In other instances, like releases and daily builds, the signed plugin should be created.