### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         id: build-signed
         uses: ./.github/build/
         env:
-          GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }}
+          GRAFANA_ACCESS_POLICY_TOKEN: ${{ secrets.GRAFANA_API_KEY }}
         with:
           release: false
           signed: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         id: build-signed
         uses: ./.github/build/
         env:
-          GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }}
+          GRAFANA_ACCESS_POLICY_TOKEN: ${{ secrets.GRAFANA_API_KEY }}
         with:
           release: true
           signed: true


### PR DESCRIPTION
The usage of GRAFANA_API_KEY environment variable is deprecated and it should be changed to GRAFANA_ACCESS_POLICY_TOKEN