### PR TITLE
Allow docker to connect to localhost Checkmk instance

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,8 @@ services:
         development: ${DEVELOPMENT:-false}
     ports:
       - 3000:3000/tcp
+    extra_hosts:
+      - checkmk.local:host-gateway
     volumes:
       - ./dist:/var/lib/grafana/plugins/tribe-29-checkmk-datasource
       - ./provisioning:/etc/grafana/provisioning


### PR DESCRIPTION
Add `extra_hosts` attribute to allow Grafana to connect to a localhost Checkmk instance trought `checkmk.local` name