### PR TITLE
fix console warning about unsupported data format

### DIFF
--- a/src/backend/rest.ts
+++ b/src/backend/rest.ts
@@ -362,7 +362,10 @@ export default class RestApiBackend implements Backend {
       // this will result in a grafana note that suggests the graph should be
       // changed to a table. By returning an empty MutableDataFrame grafana
       // shows "no data" as expected.
-      return toDataFrame({});
+      return toDataFrame({
+        refId: query.refId,
+        fields: [],
+      });
     }
   }
 


### PR DESCRIPTION
before this change you could see the following warning and error on the browser console:

```
Can not convert Object {  }
runRequest.catchError Error: Unsupported data format
```

when changing from "predefined graph" to "single metric" with an already selected predefined graph.