### PR TITLE
tests: Pin Grafana test image

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - ./checkmk-docker-hooks:/docker-entrypoint.d
 
   grafana:
-    image: grafana/grafana-oss:${GRAFANA_VERSION:-latest}
+    image: grafana/grafana-oss:${GRAFANA_VERSION:-12.4.2}
     container_name: grafana
     volumes:
       - ../dist:/var/lib/grafana/plugins/grafana-checkmk-datasource


### PR DESCRIPTION
Pin the grafana test image to grafana/grafana-oss:12.4.2 while updating the test suite to run with the newly released Grafana 13